### PR TITLE
Fixing Mem Leaks

### DIFF
--- a/src/comdlg32_dll.c
+++ b/src/comdlg32_dll.c
@@ -80,7 +80,8 @@ static BOOL WrapOFN(
 		VLA_FREE(lpstrFile_w);
 		VLA_FREE(lpstrCustomFilter_w);
 		VLA_FREE(lpstrFilter_w);
-		return ret;
+        VLA_FREE(ofn_w_raw);
+        return ret;
 	}
 }
 /// --------

--- a/src/gdi32_dll.c
+++ b/src/gdi32_dll.c
@@ -10,7 +10,9 @@ const w32u8_pair_t gdi32_pairs[] = {
 	{"CreateFontA", CreateFontU},
 	{"CreateFontIndirectA", CreateFontIndirectU},
 	{"CreateFontIndirectExA", CreateFontIndirectExU},
-	{"EnumFontsA", EnumFontFamiliesU},
+    {"AddFontResourceExA", AddFontResourceExU},
+    {"RemoveFontResourceExA", RemoveFontResourceExU},
+    {"EnumFontsA", EnumFontFamiliesU},
 	{"EnumFontFamiliesA", EnumFontFamiliesU},
 	{"EnumFontFamiliesExA", EnumFontFamiliesExU},
 	{"ExtTextOutA", ExtTextOutU},
@@ -223,6 +225,34 @@ HFONT WINAPI CreateFontIndirectExU(
 {
 	ENUMLOGFONTEXDVW elfedv_w;
 	return CreateFontIndirectExW(EnumLogfontExDVAToW(&elfedv_w, lpelfe));
+}
+
+int WINAPI AddFontResourceExU(
+    LPCSTR name,
+    DWORD fl,
+    PVOID res
+)
+{
+    int ret;
+    WCHAR_T_DEC(name);
+    WCHAR_T_CONV(name);
+    ret=AddFontResourceExW(name_w,fl,res);
+    WCHAR_T_FREE(name);
+    return ret;
+}
+
+int WINAPI RemoveFontResourceExU(
+    LPCSTR name,
+    DWORD fl,
+    PVOID res
+)
+{
+    int ret;
+    WCHAR_T_DEC(name);
+    WCHAR_T_CONV(name);
+    ret=RemoveFontResourceExW(name_w,fl,res);
+    WCHAR_T_FREE(name);
+    return ret;
 }
 
 typedef struct {

--- a/src/gdi32_dll.h
+++ b/src/gdi32_dll.h
@@ -39,6 +39,22 @@ WRAPPER_DEC(HFONT WINAPI, CreateFontIndirectEx,
 #undef CreateFontIndirectEx
 #define CreateFontIndirectEx CreateFontIndirectExU
 
+WRAPPER_DEC(int WINAPI, AddFontResourceEx,
+    LPCSTR name,
+    DWORD fl,
+    PVOID res
+);
+#undef AddFontResourceEx
+#define AddFontResourceEx AddFontResourceExU
+
+WRAPPER_DEC(int WINAPI, RemoveFontResourceEx,
+    LPCSTR name,
+    DWORD fl,
+    PVOID res
+);
+#undef RemoveFontResourceEx
+#define RemoveFontResourceEx RemoveFontResourceExU
+
 #undef EnumFonts
 #define EnumFonts EnumFontFamiliesU
 

--- a/src/kernel32_dll.c
+++ b/src/kernel32_dll.c
@@ -28,6 +28,7 @@ const w32u8_pair_t kernel32_pairs[] = {
 	{"GetPrivateProfileStringA", GetPrivateProfileStringU},
 	{"GetStartupInfoA", GetStartupInfoU},
 	{"GetTempPathA", GetTempPathU},
+    {"GetTempFileNameA", GetTempFileNameU},
 	{"IsDBCSLeadByte", IsDBCSLeadByteFB},
 	{"LoadLibraryA", LoadLibraryU},
 	{"MoveFileA", MoveFileU},
@@ -776,6 +777,27 @@ DWORD WINAPI GetTempPathU(
 )
 {
 	return WrapGetString(GetTempPathW, nBufferLength, lpBuffer);
+}
+
+UINT WINAPI GetTempFileNameU(
+    LPCSTR lpPathName,
+    LPCSTR lpPrefixString,
+    UINT uUnique,
+    LPSTR lpTempFileName
+)
+{
+    WCHAR_T_DEC(lpPathName);
+    WCHAR_T_CONV(lpPathName);
+    WCHAR_T_DEC(lpPrefixString);
+    WCHAR_T_CONV(lpPrefixString);
+    VLA(wchar_t, lpFilename_w, MAX_PATH);
+
+    UINT nSize=GetTempFileNameW(lpPathName_w,lpPrefixString_w,uUnique,lpFilename_w);
+    UINT ret = StringToUTF8(lpTempFileName, lpFilename_w, nSize);
+    VLA_FREE(lpFilename_w);
+    WCHAR_T_FREE(lpPathName);
+    WCHAR_T_FREE(lpPrefixString);
+    return ret;
 }
 
 BOOL WINAPI IsDBCSLeadByteFB(

--- a/src/kernel32_dll.h
+++ b/src/kernel32_dll.h
@@ -189,6 +189,16 @@ WRAPPER_DEC(DWORD WINAPI, GetTempPath,
 #undef GetTempPath
 #define GetTempPath GetTempPathU
 
+WRAPPER_DEC(UINT WINAPI, GetTempFileName,
+    LPCSTR lpPathName,
+    LPCSTR lpPrefixString,
+    UINT uUnique,
+    LPSTR lpTempFileName
+);
+
+#undef GetTempFileName
+#define GetTempFileName GetTempFileNameU
+
 // Only implemented using the fallback codepage, since UTF-8 has
 // no way to differentiate between continuation bytes and end bytes.
 BOOL WINAPI IsDBCSLeadByteFB(

--- a/src/macros.h
+++ b/src/macros.h
@@ -135,7 +135,7 @@ size_t zzstrlen(const char *str);
 #define WCHAR_T_CONV(src_char) \
 	if(src_char == NULL) { \
 		/* A string of length 0 can't have possibly been on the heap. */ \
-		src_char##_w = NULL; \
+        VLA_FREE(src_char##_w);\
 	} else { \
 		StringToUTF16(src_char##_w, src_char, src_char##_len) ; \
 	}

--- a/src/shell32_dll.c
+++ b/src/shell32_dll.c
@@ -7,6 +7,7 @@
   */
 
 const w32u8_pair_t shell32_pairs[] = {
+    {"ShellExecuteA", ShellExecuteU},
 	{"DragQueryFileA", DragQueryFileU},
 	{"ExtractIconA", ExtractIconU},
 	{"ExtractIconExA", ExtractIconExU},
@@ -15,6 +16,31 @@ const w32u8_pair_t shell32_pairs[] = {
 	{"SHGetPathFromIDListA", SHGetPathFromIDListU},
 	{ NULL }
 };
+
+HINSTANCE WINAPI ShellExecuteU(HWND hwnd, 
+    LPCSTR lpOperation, 
+    LPCSTR lpFile, 
+    LPCSTR lpParameters,
+    LPCSTR lpDirectory,
+    INT nShowCmd
+)
+{
+    HINSTANCE ret;
+    WCHAR_T_DEC(lpOperation);
+    WCHAR_T_CONV(lpOperation);
+    WCHAR_T_DEC(lpFile);
+    WCHAR_T_CONV(lpFile);
+    WCHAR_T_DEC(lpParameters);
+    WCHAR_T_CONV(lpParameters);
+    WCHAR_T_DEC(lpDirectory);
+    WCHAR_T_CONV(lpDirectory);
+    ret = ShellExecuteW(hwnd, lpOperation_w, lpFile_w,lpParameters_w,lpDirectory_w,nShowCmd);
+    WCHAR_T_FREE(lpOperation);
+    WCHAR_T_FREE(lpFile);
+    WCHAR_T_FREE(lpParameters);
+    WCHAR_T_FREE(lpDirectory);
+    return ret;
+}
 
 LPSTR* WINAPI CommandLineToArgvU(
 	LPCWSTR lpCmdLine,

--- a/src/shell32_dll.h
+++ b/src/shell32_dll.h
@@ -8,6 +8,17 @@
 
 #pragma once
 
+WRAPPER_DEC(HINSTANCE WINAPI, ShellExecute,
+    HWND hwnd, 
+    LPCSTR lpOperation, 
+    LPCSTR lpFile, 
+    LPCSTR lpParameters,
+    LPCSTR lpDirectory,
+    INT nShowCmd
+);
+#undef ShellExecute
+#define ShellExecute ShellExecuteU
+
 WRAPPER_DEC(LPSTR* WINAPI, CommandLineToArgv,
 	LPCWSTR lpCmdLine,
 	int* pNumArgs

--- a/src/user32_dll.h
+++ b/src/user32_dll.h
@@ -44,6 +44,8 @@ WRAPPER_DEC(HWND WINAPI, CreateWindowEx,
 // Yep, both original functions use the same parameters
 #undef DefWindowProc
 #define DefWindowProc DefWindowProcW
+#undef CallWindowProc
+#define CallWindowProc CallWindowProcW
 
 WRAPPER_DEC(INT_PTR WINAPI, DialogBoxParam,
 	HINSTANCE hInstance,
@@ -98,6 +100,17 @@ WRAPPER_DEC(BOOL WINAPI, InsertMenuItem,
 #undef InsertMenuItem
 #define InsertMenuItem InsertMenuItemU
 
+WRAPPER_DEC(BOOL WINAPI, SetMenuItemInfo,
+    HMENU hmenu,
+    UINT item,
+    BOOL fByPositon,
+    LPCMENUITEMINFOA lpmi
+);
+
+#undef SetMenuItemInfo
+#define SetMenuItemInfo SetMenuItemInfoU
+
+
 WRAPPER_DEC(int WINAPI, LoadString,
 	HINSTANCE hInstance,
 	UINT uID,
@@ -115,6 +128,16 @@ WRAPPER_DEC(int WINAPI, MessageBox,
 );
 #undef MessageBox
 #define MessageBox MessageBoxU
+
+WRAPPER_DEC(int WINAPI, IsolationAwareMessageBox,
+    HWND hWnd,
+    LPCSTR lpText,
+    LPCSTR lpCaption,
+    UINT uType
+);
+#undef IsolationAwareMessageBox
+#define IsolationAwareMessageBox IsolationAwareMessageBoxU
+
 
 WRAPPER_DEC(ATOM WINAPI, RegisterClass,
 	CONST WNDCLASSA *lpWndClass


### PR DESCRIPTION
1. Because modified strlen never returns 0, functions that receive NULL strings have a two bytes leak everytime.
2. Missing a call to free in comdlg32