### PR TITLE
Fixing Memory Leaks

### DIFF
--- a/src/comdlg32_dll.c
+++ b/src/comdlg32_dll.c
@@ -80,7 +80,8 @@ static BOOL WrapOFN(
 		VLA_FREE(lpstrFile_w);
 		VLA_FREE(lpstrCustomFilter_w);
 		VLA_FREE(lpstrFilter_w);
-		return ret;
+        VLA_FREE(ofn_w_raw);
+        return ret;
 	}
 }
 /// --------

--- a/src/macros.h
+++ b/src/macros.h
@@ -135,7 +135,7 @@ size_t zzstrlen(const char *str);
 #define WCHAR_T_CONV(src_char) \
 	if(src_char == NULL) { \
 		/* A string of length 0 can't have possibly been on the heap. */ \
-		src_char##_w = NULL; \
+        VLA_FREE(src_char##_w);\
 	} else { \
 		StringToUTF16(src_char##_w, src_char, src_char##_len) ; \
 	}


### PR DESCRIPTION
1. Because modified strlen never returns 0, functions that receive NULL strings have a two bytes leak everytime.
2. Missing a call to free in comdlg32